### PR TITLE
Add highlighting of occurences on selection

### DIFF
--- a/keymaps/styles-highlighter.cson
+++ b/keymaps/styles-highlighter.cson
@@ -9,3 +9,6 @@
 # https://atom.io/docs/latest/behind-atom-keymaps-in-depth
 #'atom-workspace':
   #'ctrl-alt-o': 'styles-highlighter:toggle'
+
+'atom-workspace':
+  'ctrl-alt-o': 'styles-highlighter:toggleOccurenceHighlighter'

--- a/menus/styles-highlighter.cson
+++ b/menus/styles-highlighter.cson
@@ -26,6 +26,8 @@
         {label: 'Clear style 9', command: 'styles-highlighter:clearNinethStyle'}
         {label: 'Clear style 10', command: 'styles-highlighter:clearTenthStyle'}
         {type: 'separator'}
+        {label: 'Toogle Occurence highlighter', command: 'styles-highlighter:toggleOccurenceHighlighter'}
+        {type: 'separator'}
         {label: 'Clear all styles', command: 'styles-highlighter:clearAllStyles'}
       ]
     }
@@ -57,6 +59,8 @@
         {label: 'Clear style 8', command: 'styles-highlighter:clearEighthStyle'}
         {label: 'Clear style 9', command: 'styles-highlighter:clearNinethStyle'}
         {label: 'Clear style 10', command: 'styles-highlighter:clearTenthStyle'}
+        {type: 'separator'}
+        {label: 'Toogle Occurence highlighter', command: 'styles-highlighter:toggleOccurenceHighlighter'}
         {type: 'separator'}
         {label: 'Clear all styles', command: 'styles-highlighter:clearAllStyles'}
       ]

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
       "styles-highlighter:clearEighthStyle",
       "styles-highlighter:clearNinethStyle",
       "styles-highlighter:clearTenthStyle",
-      "styles-highlighter:clearAllStyles"
+      "styles-highlighter:clearAllStyles",
+      "styles-highlighter:toggleOccurenceHighlighter"
     ]
   },
   "repository": "https://github.com/Tuchkata/styles-highlighter",

--- a/styles/styles-highlighter.less
+++ b/styles/styles-highlighter.less
@@ -99,4 +99,13 @@ atom-text-editor, atom-text-editor::shadow {
     background-color: rgba(174, 242, 193, 0.5);
   }
 
+  //occurence marker. Light grey, a bit darker than Atom standard selection color
+  .occurenceHighlight .region {
+    background-color: rgba(255, 255, 255, 0.125);
+  }
+
+  .occurenceHighlight.background .region {
+    background-color: rgba(255, 255, 255, 0.125);
+  }
+
 }


### PR DESCRIPTION
Since switching form Eclipse to Atom as my primary editor, I miss the feature of automatic occurence highlights troughout the document when selecting a variable/type/whatever and I think it's a good feature for styles-highlighter, so here's the implementation.

I created a pull request so you can verify if you like the idea and implementation, @Tuchkata.

Regards,
Julian
