### PR TITLE
#2 Subscribe to editor selections, so we have editor based knowledge of markings

### DIFF
--- a/lib/styles-highlighter.coffee
+++ b/lib/styles-highlighter.coffee
@@ -53,6 +53,12 @@ module.exports = StylesHighlighter =
     @subscriptions.add atom.commands.add 'atom-workspace', 'styles-highlighter:toggleOccurenceHighlighter': => @toogleHighglightOccurence()
     @subscriptions.add @editor.onDidChangeSelectionRange => @highlightOccurences()
 
+    @subscriptions.add atom.workspace.observeTextEditors (editor) => @seteditor(editor)
+
+  seteditor: (editor) ->
+    @editor = editor
+    @subscriptions.add @editor.onDidChangeSelectionRange => @highlightOccurences()
+
   # called when the windows is shutting down. If any files or resources are caught
   # by the package, they should be released here
   deactivate: ->


### PR DESCRIPTION
We need to get marking events from the active editor, so we can't just call atom.workspace.getActiveTextEditor() since in the occurence highlighter case, we need to have the editorinstance before (to subscribe to markings, so we don't have to klick a button every time we want to see occurences). 

For working around this, I introduced a subscription to atom.workspace.observeTextEditors which will push us the currently active editor instance when it changes. In this handler, we can add subscription for markings to each editor when it is opened (i.e. tab is switched).
